### PR TITLE
Grinders Pending throws error due to Djs v13 changes in sending messages to a channel

### DIFF
--- a/commands/grinders/grinders.js
+++ b/commands/grinders/grinders.js
@@ -176,7 +176,7 @@ module.exports = {
                     .setColor('GREEN')
                     .setTimestamp()
 
-                return message.channel.send({ embed })
+                return message.channel.send({ embeds: [embed] })
             }
             const mapp = q
                 .map(


### PR DESCRIPTION
major changes bought in Djs v13+ versions
```diff
- return message.channel.send({ embed })
+ return message.channel.send({ embeds: [embed] })
```